### PR TITLE
feat: add toolbar for bold and italic text, as well as shortcuts for headings

### DIFF
--- a/src/components/Editor/MarkdownEditor.tsx
+++ b/src/components/Editor/MarkdownEditor.tsx
@@ -9,7 +9,6 @@ import {
 import './MarkdownEditor.css';
 import { useStore } from '@nanostores/solid';
 import { extractNumberFromCode, isNumberHeadings } from '../../utils/key-parser';
-import { addHeading } from '../../utils/headings';
 import { ParsedStringResult, parseTableString } from '../../utils/operators/table';
 import { markdownStore, setMarkdown } from '../../store/markdown';
 import { setAlert } from '../../store/alert';
@@ -63,36 +62,6 @@ export const MarkdownEditor = () => {
         setMarkdown(result.markdown);
         textAreaElement()?.setSelectionRange(result.selected[0], result.selected[1]);
       }
-
-      // return queueMicrotask(() => {
-      //   const headingStr = addHeading(codeToNumber);
-
-      //   setMarkdown((currentValue) => {
-      //     let lastNewlineIndex = selectionStart === 0 ? 0 : selectionStart - 1;
-      //     let found = false;
-
-      //     while (!found && lastNewlineIndex > 0) {
-      //       if (currentValue.charAt(lastNewlineIndex) === '\n') {
-      //         found = true;
-      //         break;
-      //       }
-      //       lastNewlineIndex--;
-      //     }
-
-      //     if (lastNewlineIndex === 0) {
-      //       return `${headingStr}${currentValue}`;
-      //     }
-
-      //     return currentValue
-      //       .slice(0, lastNewlineIndex + 1)
-      //       .concat(headingStr)
-      //       .concat(currentValue.slice(lastNewlineIndex + 1));
-      //   });
-      //   textAreaElement()?.setSelectionRange(
-      //     selectionStart + headingStr.length,
-      //     selectionEnd + headingStr.length
-      //   );
-      // });
     } else if (e.ctrlKey || e.metaKey) {
       // Ctrl is for non-Mac, whereas metaKey is for Mac.
       let action: ToolbarAction | undefined = undefined;

--- a/src/components/Editor/RightContent.css
+++ b/src/components/Editor/RightContent.css
@@ -27,3 +27,21 @@
 .markdown-result > *:not(:first-child) {
   margin-top: theme('spacing.4');
 }
+
+.markdown-result > h1 {
+  font-size: theme('fontSize.3xl');
+}
+
+.markdown-result > h2 {
+  font-size: theme('fontSize.2xl');
+}
+
+.markdown-result > h3 {
+  font-size: theme('fontSize.xl');
+}
+
+.markdown-result > h4,
+.markdown-result > h5,
+.markdown-result > h6 {
+  font-size: theme('fontSize.lg');
+}

--- a/src/components/Editor/Toolbar/Toolbar.css
+++ b/src/components/Editor/Toolbar/Toolbar.css
@@ -1,0 +1,9 @@
+.toolbar > .button:first-of-type {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.toolbar > .button:last-of-type {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}

--- a/src/components/Editor/Toolbar/Toolbar.tsx
+++ b/src/components/Editor/Toolbar/Toolbar.tsx
@@ -1,36 +1,50 @@
 import { useStore } from '@nanostores/solid';
-import { Accessor, Setter } from 'solid-js';
+import { Accessor, JSX, Setter } from 'solid-js';
 import { markdownStore, setMarkdown } from '../../../store/markdown';
 import { getTextFromAction, ToolbarAction } from '../../../utils/operators/toolbar';
 
 interface ToolbarProps {
   selected: Accessor<[number, number] | undefined>;
   setSelected: Setter<[number, number] | undefined>;
-  textareaElement: HTMLTextAreaElement | undefined;
+  textAreaElement: Accessor<HTMLTextAreaElement | undefined>;
 }
 
-export function Toolbar({ selected, setSelected, textareaElement }: ToolbarProps) {
+export function Toolbar({ selected, setSelected, textAreaElement }: ToolbarProps) {
   const markdown = useStore(markdownStore);
+
+  const onButtonClick: JSX.DOMAttributes<HTMLButtonElement>['onClick'] = (event) => {
+    const action = event.currentTarget.dataset['action'] as ToolbarAction;
+    const result = modifyTextSelection({
+      action,
+      selected: selected(),
+      textAreaValue: markdown()
+    });
+    const textArea = textAreaElement();
+
+    if (textArea) {
+      setSelected(result.selected);
+      setMarkdown(result.markdown);
+      textArea.setSelectionRange(result.selected[0], result.selected[1]);
+      textArea.focus();
+    }
+  };
 
   return (
     <div class="space-x-1">
       <button
         class="button-sm w-8"
-        title="Add bold Markdown syntax to the selected texts"
-        onClick={() => {
-          const result = modifyTextSelection({
-            action: ToolbarAction.TOGGLE_BOLD,
-            selected,
-            textAreaValue: markdown()
-          });
-          setSelected(result.selected);
-          setMarkdown(result.markdown);
-          textareaElement?.setSelectionRange(result.selected[0], result.selected[1]);
-        }}
+        title={getToolbarHoverText('Make selected text bold', ['b'])}
+        onClick={onButtonClick}
+        data-action={ToolbarAction.TOGGLE_BOLD}
       >
         B
       </button>
-      <button class="button-sm w-8" title="Add italic Markdown syntax to the selected texts">
+      <button
+        class="button-sm w-8"
+        title={getToolbarHoverText('Make selected text italic', ['i'])}
+        onClick={onButtonClick}
+        data-action={ToolbarAction.TOGGLE_ITALIC}
+      >
         I
       </button>
     </div>
@@ -47,12 +61,11 @@ type FirstGetTextFromActionParams = Pick<
 export function modifyTextSelection({
   action,
   textAreaValue,
-  selected: selectedParam
-}: FirstGetTextFromActionParams & Pick<ToolbarProps, 'selected'>): {
+  selected
+}: FirstGetTextFromActionParams & { selected: [number, number] | undefined }): {
   selected: [number, number];
   markdown: string;
 } {
-  const selected = selectedParam();
   if (!selected) {
     return {
       selected: [0, 0],
@@ -82,4 +95,11 @@ export function modifyTextSelection({
     selected: [selectionStart + increment, selectionEnd + increment],
     markdown: result
   };
+}
+
+function getToolbarHoverText(defaultText: string, keys: string[]) {
+  if (typeof window === 'undefined') return '';
+
+  const metaKey = navigator.userAgent.includes('Macintosh') ? 'Cmd' : 'Ctrl';
+  return `${defaultText} (${metaKey}+${keys.join('+')})`;
 }

--- a/src/components/Editor/Toolbar/Toolbar.tsx
+++ b/src/components/Editor/Toolbar/Toolbar.tsx
@@ -1,0 +1,85 @@
+import { useStore } from '@nanostores/solid';
+import { Accessor, Setter } from 'solid-js';
+import { markdownStore, setMarkdown } from '../../../store/markdown';
+import { getTextFromAction, ToolbarAction } from '../../../utils/operators/toolbar';
+
+interface ToolbarProps {
+  selected: Accessor<[number, number] | undefined>;
+  setSelected: Setter<[number, number] | undefined>;
+  textareaElement: HTMLTextAreaElement | undefined;
+}
+
+export function Toolbar({ selected, setSelected, textareaElement }: ToolbarProps) {
+  const markdown = useStore(markdownStore);
+
+  return (
+    <div class="space-x-1">
+      <button
+        class="button-sm w-8"
+        title="Add bold Markdown syntax to the selected texts"
+        onClick={() => {
+          const result = modifyTextSelection({
+            action: ToolbarAction.TOGGLE_BOLD,
+            selected,
+            textAreaValue: markdown()
+          });
+          setSelected(result.selected);
+          setMarkdown(result.markdown);
+          textareaElement?.setSelectionRange(result.selected[0], result.selected[1]);
+        }}
+      >
+        B
+      </button>
+      <button class="button-sm w-8" title="Add italic Markdown syntax to the selected texts">
+        I
+      </button>
+    </div>
+  );
+}
+
+// Helper functions.
+type FirstGetTextFromActionParams = Pick<
+  Parameters<typeof getTextFromAction>['0'],
+  'action' | 'textAreaValue'
+>;
+
+// Used to prevent duplication in MarkdownEditor component.
+export function modifyTextSelection({
+  action,
+  textAreaValue,
+  selected: selectedParam
+}: FirstGetTextFromActionParams & Pick<ToolbarProps, 'selected'>): {
+  selected: [number, number];
+  markdown: string;
+} {
+  const selected = selectedParam();
+  if (!selected) {
+    return {
+      selected: [0, 0],
+      markdown: textAreaValue
+    };
+  }
+
+  const [selectionStart, selectionEnd] = selected;
+  const result = getTextFromAction({
+    action,
+    textAreaValue,
+    selectionEnd,
+    selectionStart
+  });
+  let increment = action.length;
+
+  if (result.length < textAreaValue.length) {
+    // Removal.
+    increment *= -1;
+  } else {
+    // Otherwise, do nothing. This is adding the syntax process.
+  }
+
+  return {
+    // Increment the selection, because we are adding new characters before the text.
+    // Or, decrement the selection indices, because of the same reason.
+    selected: [selectionStart + increment, selectionEnd + increment],
+    markdown: result
+  };
+}

--- a/src/components/Editor/Toolbar/index.tsx
+++ b/src/components/Editor/Toolbar/index.tsx
@@ -1,0 +1,1 @@
+export * from './Toolbar';

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -54,7 +54,7 @@ if (import.meta.env.VERSION && import.meta.env.GIT_HASH) {
       <slot />
     </main>
 
-    <footer class="py-2 text-xs text-center bg-sky-100 text-slate-700">
+    <footer class="py-2 text-xs text-center border-t-gray-200 border text-slate-700">
       <div>Copyright © {currentYear} Try Ajitiono</div>
       <div class="text-slate-400">Build {version} ({currentYear}{currentMonth}{currentDate})</div>
     </footer>

--- a/src/utils/headings.ts
+++ b/src/utils/headings.ts
@@ -1,8 +1,0 @@
-export function addHeading(headingLevel: number) {
-  let str = '';
-  for (let i = 0; i < headingLevel; i++) {
-    str += '#';
-  }
-
-  return `${str} `;
-}

--- a/src/utils/key-parser.ts
+++ b/src/utils/key-parser.ts
@@ -1,3 +1,4 @@
-export function isKeycodeNumber(key: string) {
-  return !isNaN(Number(key));
+export function extractNumberFromCode(code: string) {
+  // For example: Digit3.
+  return Number(code.slice('Digit'.length));
 }

--- a/src/utils/key-parser.ts
+++ b/src/utils/key-parser.ts
@@ -2,3 +2,7 @@ export function extractNumberFromCode(code: string) {
   // For example: Digit3.
   return Number(code.slice('Digit'.length));
 }
+
+export function isNumberHeadings(value: number): value is 1 | 2 | 3 | 4 | 5 | 6 {
+  return !isNaN(value) && value > 0 && value < 7;
+}

--- a/src/utils/operators/toolbar.test.ts
+++ b/src/utils/operators/toolbar.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'vitest';
+import { getTextFromAction, ToolbarAction } from './toolbar';
+
+describe('getTextFromAction', () => {
+  describe('singles', () => {
+    test('bold', () => {
+      const initial = 'test helloworld test';
+      let result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_BOLD,
+        selectionStart: initial.indexOf('helloworld'),
+
+        selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: initial
+      });
+
+      expect(result).toBe('test **helloworld** test');
+
+      // Revert back.
+      result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_BOLD,
+        selectionStart: result.indexOf('helloworld'),
+        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: result
+      });
+
+      expect(result).toBe('test helloworld test');
+    });
+
+    test('italic', () => {
+      const initial = 'test helloworld test';
+      let result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_ITALIC,
+        selectionStart: initial.indexOf('helloworld'),
+
+        selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: initial
+      });
+
+      expect(result).toBe('test _helloworld_ test');
+
+      // Revert back.
+      result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_ITALIC,
+        selectionStart: result.indexOf('helloworld'),
+        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: result
+      });
+
+      expect(result).toBe('test helloworld test');
+    });
+  });
+
+  describe('couples', () => {
+    test('bold and italic', () => {
+      // Bold first.
+      const initial = 'test helloworld test';
+      let result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_BOLD,
+        selectionStart: initial.indexOf('helloworld'),
+
+        selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: initial
+      });
+
+      expect(result).toBe('test **helloworld** test');
+
+      // Then, italic.
+      result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_ITALIC,
+        selectionStart: result.indexOf('helloworld'),
+        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: result
+      });
+
+      expect(result).toBe('test **_helloworld_** test');
+
+      // Revert back.
+      result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_ITALIC,
+        selectionStart: result.indexOf('helloworld'),
+        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: result
+      });
+
+      expect(result).toBe('test **helloworld** test');
+
+      result = getTextFromAction({
+        action: ToolbarAction.TOGGLE_BOLD,
+        selectionStart: result.indexOf('helloworld'),
+        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+        textAreaValue: result
+      });
+
+      expect(result).toBe(initial);
+    });
+  });
+});

--- a/src/utils/operators/toolbar.test.ts
+++ b/src/utils/operators/toolbar.test.ts
@@ -2,96 +2,162 @@ import { describe, expect, test } from 'vitest';
 import { getTextFromAction, ToolbarAction } from './toolbar';
 
 describe('getTextFromAction', () => {
-  describe('singles', () => {
-    test('bold', () => {
-      const initial = 'test helloworld test';
-      let result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_BOLD,
-        selectionStart: initial.indexOf('helloworld'),
+  test('headings', () => {
+    let initial = `
+test123
 
-        selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: initial
-      });
-
-      expect(result).toBe('test **helloworld** test');
-
-      // Revert back.
-      result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_BOLD,
-        selectionStart: result.indexOf('helloworld'),
-        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: result
-      });
-
-      expect(result).toBe('test helloworld test');
+helloworld. This is a sample text
+    `.trim();
+    let result = getTextFromAction({
+      action: ToolbarAction.TOOLBAR_HEADING_1,
+      selectionEnd: initial.indexOf('3'),
+      selectionStart: initial.indexOf('3'),
+      textAreaValue: initial
     });
 
-    test('italic', () => {
-      const initial = 'test helloworld test';
-      let result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_ITALIC,
-        selectionStart: initial.indexOf('helloworld'),
+    expect(result).toBe(
+      `
+# test123
 
-        selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: initial
-      });
+helloworld. This is a sample text
+    `.trim()
+    );
 
-      expect(result).toBe('test _helloworld_ test');
-
-      // Revert back.
-      result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_ITALIC,
-        selectionStart: result.indexOf('helloworld'),
-        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: result
-      });
-
-      expect(result).toBe('test helloworld test');
+    // Try revert.
+    result = getTextFromAction({
+      action: ToolbarAction.TOOLBAR_HEADING_1,
+      selectionEnd: result.indexOf('3'),
+      selectionStart: result.indexOf('3'),
+      textAreaValue: result
     });
+
+    expect(result).toBe(initial);
+
+    // Try adding the heading again, this time heading 2.
+    result = getTextFromAction({
+      action: ToolbarAction.TOOLBAR_HEADING_2,
+      selectionEnd: result.indexOf('3'),
+      selectionStart: result.indexOf('3'),
+      textAreaValue: result
+    });
+
+    expect(result).toBe(
+      `
+## test123
+
+helloworld. This is a sample text
+    `.trim()
+    );
+
+    // Try adding heading 3, the previous heading should be replaced.
+    result = getTextFromAction({
+      action: ToolbarAction.TOOLBAR_HEADING_3,
+      selectionEnd: result.indexOf('3'),
+      selectionStart: result.indexOf('3'),
+      textAreaValue: result
+    });
+
+    expect(result).toBe(
+      `
+### test123
+
+helloworld. This is a sample text
+    `.trim()
+    );
   });
 
-  describe('couples', () => {
-    test('bold and italic', () => {
-      // Bold first.
-      const initial = 'test helloworld test';
-      let result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_BOLD,
-        selectionStart: initial.indexOf('helloworld'),
+  describe('formattings', () => {
+    describe('singles', () => {
+      test('bold', () => {
+        const initial = 'test helloworld test';
+        let result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_BOLD,
+          selectionStart: initial.indexOf('helloworld'),
 
-        selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: initial
+          selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: initial
+        });
+
+        expect(result).toBe('test **helloworld** test');
+
+        // Revert back.
+        result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_BOLD,
+          selectionStart: result.indexOf('helloworld'),
+          selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: result
+        });
+
+        expect(result).toBe('test helloworld test');
       });
 
-      expect(result).toBe('test **helloworld** test');
+      test('italic', () => {
+        const initial = 'test helloworld test';
+        let result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_ITALIC,
+          selectionStart: initial.indexOf('helloworld'),
 
-      // Then, italic.
-      result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_ITALIC,
-        selectionStart: result.indexOf('helloworld'),
-        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: result
+          selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: initial
+        });
+
+        expect(result).toBe('test _helloworld_ test');
+
+        // Revert back.
+        result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_ITALIC,
+          selectionStart: result.indexOf('helloworld'),
+          selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: result
+        });
+
+        expect(result).toBe('test helloworld test');
       });
+    });
 
-      expect(result).toBe('test **_helloworld_** test');
+    describe('couples', () => {
+      test('bold and italic', () => {
+        // Bold first.
+        const initial = 'test helloworld test';
+        let result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_BOLD,
+          selectionStart: initial.indexOf('helloworld'),
 
-      // Revert back.
-      result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_ITALIC,
-        selectionStart: result.indexOf('helloworld'),
-        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: result
+          selectionEnd: initial.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: initial
+        });
+
+        expect(result).toBe('test **helloworld** test');
+
+        // Then, italic.
+        result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_ITALIC,
+          selectionStart: result.indexOf('helloworld'),
+          selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: result
+        });
+
+        expect(result).toBe('test **_helloworld_** test');
+
+        // Revert back.
+        result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_ITALIC,
+          selectionStart: result.indexOf('helloworld'),
+          selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: result
+        });
+
+        expect(result).toBe('test **helloworld** test');
+
+        result = getTextFromAction({
+          action: ToolbarAction.TOGGLE_BOLD,
+          selectionStart: result.indexOf('helloworld'),
+          selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
+          textAreaValue: result
+        });
+
+        expect(result).toBe(initial);
       });
-
-      expect(result).toBe('test **helloworld** test');
-
-      result = getTextFromAction({
-        action: ToolbarAction.TOGGLE_BOLD,
-        selectionStart: result.indexOf('helloworld'),
-        selectionEnd: result.indexOf('helloworld') + 'helloworld'.length,
-        textAreaValue: result
-      });
-
-      expect(result).toBe(initial);
     });
   });
 });

--- a/src/utils/operators/toolbar.ts
+++ b/src/utils/operators/toolbar.ts
@@ -39,18 +39,19 @@ export function getTextFromAction({
     case ToolbarAction.TOOLBAR_HEADING_4:
     case ToolbarAction.TOOLBAR_HEADING_5:
     case ToolbarAction.TOOLBAR_HEADING_6: {
-      let lastNewlineIndex = selectionStart === 0 ? 0 : selectionStart - 1;
+      let indexOfLineStart = selectionStart === 0 ? 0 : selectionStart - 1;
       let found = false;
 
-      while (!found && lastNewlineIndex > 0) {
-        if (newText.charAt(lastNewlineIndex) === '\n') {
+      while (!found && indexOfLineStart > 0) {
+        if (newText.charAt(indexOfLineStart) === '\n') {
+          indexOfLineStart += 1;
           found = true;
           break;
         }
-        lastNewlineIndex--;
+        indexOfLineStart--;
       }
 
-      let nextNewLine = newText.slice(lastNewlineIndex).indexOf('\n');
+      let nextNewLine = newText.indexOf('\n', indexOfLineStart);
       if (nextNewLine === -1) {
         // A full text without paragraph.
         // Make entire text the heading.
@@ -58,7 +59,7 @@ export function getTextFromAction({
       }
 
       const headingStr = `${action} `;
-      let substr = newText.slice(lastNewlineIndex, nextNewLine);
+      let substr = newText.slice(indexOfLineStart, nextNewLine);
 
       if (substr.startsWith(headingStr)) {
         // Heading exists, so we remove it.
@@ -73,7 +74,7 @@ export function getTextFromAction({
       }
 
       newText = newText
-        .slice(0, lastNewlineIndex)
+        .slice(0, indexOfLineStart)
         .concat(substr)
         .concat(newText.slice(nextNewLine));
 

--- a/src/utils/operators/toolbar.ts
+++ b/src/utils/operators/toolbar.ts
@@ -1,0 +1,40 @@
+export enum ToolbarAction {
+  TOGGLE_BOLD = '**',
+  TOGGLE_ITALIC = '_'
+}
+
+export function getTextFromAction({
+  textAreaValue,
+  selectionStart,
+  selectionEnd,
+  action
+}: {
+  textAreaValue: string;
+  selectionStart: number;
+  selectionEnd: number;
+  action: ToolbarAction;
+}) {
+  const charsLength = action.length;
+  let newText = textAreaValue;
+
+  if (
+    textAreaValue.slice(selectionStart - charsLength, selectionStart) === action &&
+    textAreaValue.slice(selectionEnd, selectionEnd + charsLength) === action
+  ) {
+    // Remove.
+    newText = newText
+      .slice(0, selectionStart - charsLength)
+      .concat(newText.slice(selectionStart, selectionEnd))
+      .concat(newText.slice(selectionEnd + charsLength));
+  } else {
+    // Append.
+    newText = newText
+      .slice(0, selectionStart)
+      .concat(action)
+      .concat(newText.slice(selectionStart, selectionEnd))
+      .concat(action)
+      .concat(newText.slice(selectionEnd));
+  }
+
+  return newText;
+}

--- a/src/utils/operators/toolbar.ts
+++ b/src/utils/operators/toolbar.ts
@@ -1,6 +1,12 @@
 export enum ToolbarAction {
   TOGGLE_BOLD = '**',
-  TOGGLE_ITALIC = '_'
+  TOGGLE_ITALIC = '_',
+  TOOLBAR_HEADING_1 = '#',
+  TOOLBAR_HEADING_2 = '##',
+  TOOLBAR_HEADING_3 = '###',
+  TOOLBAR_HEADING_4 = '####',
+  TOOLBAR_HEADING_5 = '######',
+  TOOLBAR_HEADING_6 = '#######'
 }
 
 export function getTextFromAction({
@@ -14,27 +20,102 @@ export function getTextFromAction({
   selectionEnd: number;
   action: ToolbarAction;
 }) {
-  const charsLength = action.length;
   let newText = textAreaValue;
 
-  if (
-    textAreaValue.slice(selectionStart - charsLength, selectionStart) === action &&
-    textAreaValue.slice(selectionEnd, selectionEnd + charsLength) === action
-  ) {
-    // Remove.
-    newText = newText
-      .slice(0, selectionStart - charsLength)
-      .concat(newText.slice(selectionStart, selectionEnd))
-      .concat(newText.slice(selectionEnd + charsLength));
-  } else {
-    // Append.
-    newText = newText
-      .slice(0, selectionStart)
-      .concat(action)
-      .concat(newText.slice(selectionStart, selectionEnd))
-      .concat(action)
-      .concat(newText.slice(selectionEnd));
+  switch (action) {
+    case ToolbarAction.TOGGLE_BOLD:
+    case ToolbarAction.TOGGLE_ITALIC: {
+      newText = toggleTextWrap({
+        text: newText,
+        chars: action,
+        selectionEnd,
+        selectionStart
+      });
+      break;
+    }
+    case ToolbarAction.TOOLBAR_HEADING_1:
+    case ToolbarAction.TOOLBAR_HEADING_2:
+    case ToolbarAction.TOOLBAR_HEADING_3:
+    case ToolbarAction.TOOLBAR_HEADING_4:
+    case ToolbarAction.TOOLBAR_HEADING_5:
+    case ToolbarAction.TOOLBAR_HEADING_6: {
+      let lastNewlineIndex = selectionStart === 0 ? 0 : selectionStart - 1;
+      let found = false;
+
+      while (!found && lastNewlineIndex > 0) {
+        if (newText.charAt(lastNewlineIndex) === '\n') {
+          found = true;
+          break;
+        }
+        lastNewlineIndex--;
+      }
+
+      let nextNewLine = newText.slice(lastNewlineIndex).indexOf('\n');
+      if (nextNewLine === -1) {
+        // A full text without paragraph.
+        // Make entire text the heading.
+        nextNewLine = newText.length;
+      }
+
+      const headingStr = `${action} `;
+      let substr = newText.slice(lastNewlineIndex, nextNewLine);
+
+      if (substr.startsWith(headingStr)) {
+        // Heading exists, so we remove it.
+        substr = substr.slice(headingStr.length);
+      } else if (substr.startsWith('#')) {
+        // Different heading level.
+        // We replace.
+        substr = headingStr.concat(substr.slice(substr.indexOf(' ') + 1));
+      } else {
+        // Addition.
+        substr = `${headingStr}${substr}`;
+      }
+
+      newText = newText
+        .slice(0, lastNewlineIndex)
+        .concat(substr)
+        .concat(newText.slice(nextNewLine));
+
+      break;
+    }
+    default:
+      break;
   }
 
   return newText;
+}
+
+// Helper functions.
+function toggleTextWrap({
+  text,
+  selectionEnd,
+  selectionStart,
+  chars
+}: {
+  text: string;
+  selectionStart: number;
+  selectionEnd: number;
+  chars: string;
+}) {
+  const charsLength = chars.length;
+
+  if (
+    text.slice(selectionStart - charsLength, selectionStart) === chars &&
+    text.slice(selectionEnd, selectionEnd + charsLength) === chars
+  ) {
+    // Remove.
+    return text
+      .slice(0, selectionStart - charsLength)
+      .concat(text.slice(selectionStart, selectionEnd))
+      .concat(text.slice(selectionEnd + charsLength));
+  }
+
+  // Append.
+  return text
+    .slice(0, selectionStart)
+    .concat(chars)
+    .concat(text.slice(selectionStart, selectionEnd))
+    .concat(chars)
+    .concat(text.slice(selectionEnd));
 }


### PR DESCRIPTION
Closes https://github.com/imballinst/markdownclap/issues/3. Features included:

1. Add toolbar for buttons in bold and italic
2. Add shortcuts for bold and italic, as well as heading 1-6
3. Some refactors and fixes, e.g. selecting via keyboard doesn't trigger Inspect Element button check

Also includes unit tests.

https://user-images.githubusercontent.com/7077157/193382431-ff9abd3c-2efe-4c1c-a619-84dfe00839aa.mov