### PR TITLE
fix: fix table cursor not going to the end of the pasted table

### DIFF
--- a/src/components/Editor/MarkdownEditor.tsx
+++ b/src/components/Editor/MarkdownEditor.tsx
@@ -202,6 +202,9 @@ export const MarkdownEditor = () => {
             setMarkdown((prev) =>
               prev.slice(0, selectionStart).concat(parseResult).concat(prev.slice(selectionStart))
             );
+
+            const nextSelectionRange = selectionStart + parseResult.length;
+            e.currentTarget.setSelectionRange(nextSelectionRange, nextSelectionRange);
           }
         }}
       />


### PR DESCRIPTION
Closes https://github.com/imballinst/markdownclap/issues/21.